### PR TITLE
#20 Added http transport to collect logs

### DIFF
--- a/srvlog-it/src/test/java/com/payneteasy/srvlog/logsender/LogSenderWebTest.java
+++ b/srvlog-it/src/test/java/com/payneteasy/srvlog/logsender/LogSenderWebTest.java
@@ -1,0 +1,45 @@
+package com.payneteasy.srvlog.logsender;
+
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsMessage;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsRequest;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsResponse;
+import com.payneteasy.srvlog.ui.CommonUiIntegrationTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static com.payneteasy.srvlog.adapter.json.messages.SaveLogsStatus.SUCCESS;
+import static com.payneteasy.srvlog.data.LogFacility.local0;
+import static com.payneteasy.srvlog.data.LogLevel.DEBUG;
+import static java.lang.System.currentTimeMillis;
+
+public class LogSenderWebTest extends CommonUiIntegrationTest {
+
+
+    @Test
+    public void sendLog() {
+        SaveLogsClient   client   = new SaveLogsClient("http://localhost:8080");
+        SaveLogsRequest  request  = createSampleRequest();
+        SaveLogsResponse response = client.saveLogs("127.0.0.1", request);
+        Assert.assertEquals(request.getRequestId(), response.getRequestId());
+        Assert.assertEquals(SUCCESS, response.getStatus());
+    }
+
+    private SaveLogsRequest createSampleRequest() {
+        ArrayList<SaveLogsMessage> messages = new ArrayList<>();
+        messages.add(new SaveLogsMessage(currentTimeMillis(), "test", local0.getValue(), DEBUG.getValue(), "message 1"));
+        messages.add(new SaveLogsMessage(currentTimeMillis(), "test", local0.getValue(), DEBUG.getValue(), "message 2"));
+        return new SaveLogsRequest(UUID.randomUUID().toString(), messages);
+    }
+
+
+    @Override
+    @After
+    public void tearDown() {
+        super.tearDown();
+    }
+
+}

--- a/srvlog-it/src/test/java/com/payneteasy/srvlog/logsender/SaveLogsClient.java
+++ b/srvlog-it/src/test/java/com/payneteasy/srvlog/logsender/SaveLogsClient.java
@@ -1,0 +1,130 @@
+package com.payneteasy.srvlog.logsender;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.payneteasy.srvlog.adapter.json.ISaveLogsService;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsRequest;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+public class SaveLogsClient implements ISaveLogsService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SaveLogsClient.class);
+
+    private final String       baseUrl;
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
+
+    public SaveLogsClient(String baseUrl) {
+        this.baseUrl = baseUrl;
+
+        ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(NON_NULL);
+
+        reader = mapper.readerFor(SaveLogsResponse.class);
+        writer = mapper.writerFor(SaveLogsRequest.class);
+    }
+
+    @Override
+    public SaveLogsResponse saveLogs(String aRemoteIpAddress, SaveLogsRequest aLogs) {
+        return sendJson(baseUrl + "/save-logs", aLogs);
+    }
+
+    private <T> T sendJson(String url, Object aRequest) {
+
+        HttpURLConnection connection = prepareConnection(url);
+        connection.setRequestProperty("token", "test-token-197dc68c-34e5-11eb-9fbd-7bb165d4566c");
+        
+        try {
+            connection.connect();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot connect to " + url, e);
+        }
+
+        try {
+            String json = writer.writeValueAsString(aRequest);
+            LOG.debug("Sending to {} json: {}", url, json);
+            connection.getOutputStream().write(json.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot get output stream for " + url, e);
+        }
+
+        int status;
+        try {
+            status = connection.getResponseCode();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot wait for response code for " + url, e);
+        }
+
+        if (status != 200) {
+            throw new IllegalStateException("Wrong response code " + status);
+        }
+
+        InputStream inputStream;
+        try {
+            inputStream = status >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot get input stream for " + url, e);
+        }
+
+        try {
+            byte[] body = readAllBytes(inputStream);
+            String json = new String(body, StandardCharsets.UTF_8);
+            LOG.debug("Received json: {}", json);
+            return reader.readValue(json);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read value from " + url, e);
+        }
+
+    }
+
+    private HttpURLConnection prepareConnection(String url) {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setReadTimeout(10_000);
+            connection.setConnectTimeout(10_000);
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+            return connection;
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create connection to " + url, e);
+        }
+    }
+
+    public static byte[] readAllBytes(InputStream aInputStream) throws IOException {
+        List<byte[]> list   = new ArrayList<>();
+        byte[]       buffer = new byte[2048];
+        int          count;
+
+        while( (count = aInputStream.read(buffer)) >= 0) {
+            byte[] bytes = new byte[count];
+            System.arraycopy(buffer, 0, bytes, 0, count);
+            list.add(bytes);
+        }
+
+        int size = 0;
+        for (byte[] bytes : list) {
+            size += bytes.length;
+        }
+
+        byte[] output = new byte[size];
+        int position = 0;
+        for (byte[] bytes : list) {
+            System.arraycopy(bytes, 0, output, position, bytes.length);
+            position += bytes.length;
+        }
+        return output;
+    }
+
+}

--- a/srvlog-it/src/test/resources/logback-test.xml
+++ b/srvlog-it/src/test/resources/logback-test.xml
@@ -24,6 +24,8 @@
 -->
   <logger name="com.payneteasy.srvlog.adapter" level="DEBUG"/>
   <logger name="com.payneteasy.srvlog" level="INFO"/>
+  <logger name="com.payneteasy.srvlog.logsender" level="DEBUG"/>
+  
   <root level="INFO">
     <appender-ref ref="console"/>
     <!--<appender-ref ref="file"/>-->

--- a/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/ISaveLogsService.java
+++ b/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/ISaveLogsService.java
@@ -1,0 +1,14 @@
+package com.payneteasy.srvlog.adapter.json;
+
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsRequest;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsResponse;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface ISaveLogsService {
+
+    @Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
+    SaveLogsResponse saveLogs(String aRemoteIpAddress, SaveLogsRequest aLogs);
+
+}

--- a/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/SaveLogsServiceImpl.java
+++ b/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/SaveLogsServiceImpl.java
@@ -1,0 +1,58 @@
+package com.payneteasy.srvlog.adapter.json;
+
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsMessage;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsRequest;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsResponse;
+import com.payneteasy.srvlog.data.LogData;
+import com.payneteasy.srvlog.service.ILogCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class SaveLogsServiceImpl implements ISaveLogsService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SaveLogsServiceImpl.class);
+
+    private final ILogCollector logCollector;
+
+    @Autowired
+    public SaveLogsServiceImpl(ILogCollector logCollector) {
+        this.logCollector = logCollector;
+    }
+
+    @Override
+    public SaveLogsResponse saveLogs(String aRemoveIpAddress, SaveLogsRequest aLogs) {
+        if(aLogs.getMessages() == null) {
+            return SaveLogsResponse.error(aLogs.getRequestId(), "No messages");
+        }
+
+        for (SaveLogsMessage message : aLogs.getMessages()) {
+            LogData logData = mapMessage(aRemoveIpAddress, message);
+
+            try {
+                logCollector.saveLog(logData);
+            } catch (Exception e) {
+                throw new IllegalStateException("Cannot save log", e);
+            }
+        }
+
+        LOG.debug("Saved {} with {} messages from {}", aLogs.getRequestId(), aLogs.getMessages().size(), aRemoveIpAddress);
+        
+        return SaveLogsResponse.success(aLogs.getRequestId());
+    }
+
+    private LogData mapMessage(String aRemoveIpAddress, SaveLogsMessage aMessage) {
+        LogData data = new LogData();
+        data.setDate     ( new Date(aMessage.getTime()) );
+        data.setHost     ( aRemoveIpAddress             );
+        data.setFacility ( aMessage.getFacility()       );
+        data.setSeverity ( aMessage.getSeverity()       );
+        data.setMessage  ( aMessage.getMessage()        );
+        data.setProgram  ( aMessage.getProgram()        );
+        return data;
+    }
+}

--- a/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsMessage.java
+++ b/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsMessage.java
@@ -1,0 +1,54 @@
+package com.payneteasy.srvlog.adapter.json.messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.beans.ConstructorProperties;
+
+public class SaveLogsMessage {
+
+    @JsonProperty("time")     private final long    time;
+    @JsonProperty("program")  private final String  program;
+    @JsonProperty("facility") private final Integer facility;
+    @JsonProperty("severity") private final Integer severity;
+    @JsonProperty("message")  private final String  message;
+
+    @ConstructorProperties({"time", "program", "facility", "severity", "message"})
+    public SaveLogsMessage(long time, String program, Integer facility, Integer severity, String message) {
+        this.time = time;
+        this.program = program;
+        this.facility = facility;
+        this.severity = severity;
+        this.message = message;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public String getProgram() {
+        return program;
+    }
+
+    public Integer getFacility() {
+        return facility;
+    }
+
+    public Integer getSeverity() {
+        return severity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "SaveLogsMessage{" +
+                "time=" + time +
+                ", program='" + program + '\'' +
+                ", facility=" + facility +
+                ", severity=" + severity +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsRequest.java
+++ b/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsRequest.java
@@ -1,0 +1,26 @@
+package com.payneteasy.srvlog.adapter.json.messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+public class SaveLogsRequest {
+
+    @JsonProperty("requestId") private final String                requestId;
+    @JsonProperty("messages" ) private final List<SaveLogsMessage> messages;
+
+    @ConstructorProperties({"requestId", "messages"})
+    public SaveLogsRequest(String requestId, List<SaveLogsMessage> messages) {
+        this.requestId = requestId;
+        this.messages = messages;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public List<SaveLogsMessage> getMessages() {
+        return messages;
+    }
+}

--- a/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsResponse.java
+++ b/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsResponse.java
@@ -1,0 +1,50 @@
+package com.payneteasy.srvlog.adapter.json.messages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.beans.ConstructorProperties;
+import java.util.UUID;
+
+public class SaveLogsResponse {
+
+    private final String         requestId;
+    private final SaveLogsStatus status;
+    private final String         errorMessage;
+    private final String         errorId;
+
+    @ConstructorProperties({"requestId", "status", "errorMessage", "errorId"})
+    private SaveLogsResponse(String requestId, SaveLogsStatus status, String errorMessage, String errorId) {
+        this.requestId = requestId;
+        this.status = status;
+        this.errorMessage = errorMessage;
+        this.errorId = errorId;
+    }
+
+    public static SaveLogsResponse error(String aRequestId, String aErrorMessage) {
+        return new SaveLogsResponse(aRequestId, SaveLogsStatus.ERROR, aErrorMessage, UUID.randomUUID().toString());
+    }
+
+    public static SaveLogsResponse success(String aRequestId) {
+        return new SaveLogsResponse(aRequestId, SaveLogsStatus.SUCCESS, null, null);
+    }
+
+    @JsonProperty("requestId" )
+    public String getRequestId() {
+        return requestId;
+    }
+
+    @JsonProperty("status" )
+    public SaveLogsStatus getStatus() {
+        return status;
+    }
+
+    @JsonProperty("errorMessage" )
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @JsonProperty("errorId")
+    public String getErrorId() {
+        return errorId;
+    }
+}

--- a/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsStatus.java
+++ b/srvlog-service/src/main/java/com/payneteasy/srvlog/adapter/json/messages/SaveLogsStatus.java
@@ -1,0 +1,7 @@
+package com.payneteasy.srvlog.adapter.json.messages;
+
+public enum  SaveLogsStatus {
+
+    SUCCESS, ERROR
+
+}

--- a/srvlog-web/src/main/java/com/payneteasy/srvlog/servlet/HttpServletResponseWriter.java
+++ b/srvlog-web/src/main/java/com/payneteasy/srvlog/servlet/HttpServletResponseWriter.java
@@ -1,0 +1,55 @@
+package com.payneteasy.srvlog.servlet;
+
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+
+public class HttpServletResponseWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpServletResponseWriter.class);
+
+    private final HttpServletResponse response;
+    private final ObjectWriter        objectWriter;
+
+    public HttpServletResponseWriter(HttpServletResponse response, ObjectWriter objectWriter) {
+        this.response = response;
+        this.objectWriter = objectWriter;
+    }
+
+    public void writeError(int aStatusCode, String aReason, Exception aException) {
+        LOG.error(aReason, aException);
+        writeError(aStatusCode, aReason);
+    }
+
+    public void writeError(int aStatusCode, String aReason) {
+        LOG.error(aReason);
+        try {
+            response.setStatus(aStatusCode);
+            response.setContentType("application/json");
+            writeJson(SaveLogsResponse.error(null, aReason));
+        } catch (Exception e) {
+            LOG.error("Cannot write response", e);
+        }
+    }
+
+    public void writeJson(Object aMessage) {
+        response.setContentType("application/json");
+        PrintWriter writer;
+        try {
+            writer = response.getWriter();
+        } catch (Exception e) {
+            LOG.error("Cannot get writer", e);
+            return;
+        }
+
+        try {
+            objectWriter.writeValue(writer, aMessage);
+        } catch (Exception e) {
+            LOG.error("Cannot write value", e);
+        }
+    }
+}

--- a/srvlog-web/src/main/java/com/payneteasy/srvlog/servlet/SaveLogsServlet.java
+++ b/srvlog-web/src/main/java/com/payneteasy/srvlog/servlet/SaveLogsServlet.java
@@ -1,0 +1,94 @@
+package com.payneteasy.srvlog.servlet;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.payneteasy.srvlog.adapter.json.ISaveLogsService;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsRequest;
+import com.payneteasy.srvlog.adapter.json.messages.SaveLogsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+
+public class SaveLogsServlet extends HttpServlet {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SaveLogsServlet.class);
+
+    private ISaveLogsService saveLogsService;
+    private String           token;
+
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
+
+    public SaveLogsServlet() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        
+        reader = mapper.readerFor(SaveLogsRequest.class);
+        writer = mapper.writerFor(SaveLogsResponse.class);
+    }
+
+
+    @Override
+    public void init() throws ServletException {
+        WebApplicationContext webApplicationContext = WebApplicationContextUtils.findWebApplicationContext(getServletContext());
+        saveLogsService = webApplicationContext.getBean(ISaveLogsService.class);
+        if(saveLogsService == null) {
+            throw new ServletException("No ILogCollector found");
+        }
+
+        // disable cookies
+        getServletContext().setSessionTrackingModes(Collections.emptySet());
+
+        token = getServletContext().getInitParameter("save-logs-token").trim();
+
+        LOG.info("Initialized save-logs servlet ({})", getServletConfig().getServletName());
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest aRequest, HttpServletResponse aResponse) {
+        HttpServletResponseWriter servletWriter = new HttpServletResponseWriter(aResponse, writer);
+
+        if(!token.equals(aRequest.getHeader("token"))) {
+            servletWriter.writeError(HttpServletResponse.SC_UNAUTHORIZED, "Wrong access token");
+            return;
+        }
+
+
+        SaveLogsRequest saveRequest;
+        try {
+            saveRequest = reader.readValue(aRequest.getReader());
+        } catch (UnrecognizedPropertyException e) {
+            servletWriter.writeError(HttpServletResponse.SC_BAD_REQUEST, "Unknown field '" + e.getPropertyName().replace("com.payneteasy.srvlog.adapter.json.messages.", "") + "'", e);
+            return;
+        } catch (JsonParseException|JsonMappingException e) {
+            servletWriter.writeError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage(), e);
+            return;
+        } catch (Exception e) {
+            servletWriter.writeError(HttpServletResponse.SC_BAD_REQUEST, "Cannot parse input request", e);
+            return;
+        }
+
+        SaveLogsResponse saveResponse;
+        try {
+            saveResponse = saveLogsService.saveLogs(aRequest.getRemoteAddr(), saveRequest);
+        } catch (Exception e) {
+            LOG.error("Cannot save logs", e);
+            saveResponse = SaveLogsResponse.error(saveRequest.getRequestId(), "Cannot save logs");
+        }
+
+        servletWriter.writeJson(saveResponse);
+
+    }
+}

--- a/srvlog-web/src/main/webapp/WEB-INF/web.xml
+++ b/srvlog-web/src/main/webapp/WEB-INF/web.xml
@@ -23,6 +23,11 @@
         <param-value>true</param-value>
     </context-param>
 
+    <context-param>
+        <param-name>save-logs-token</param-name>
+        <param-value>test-token-197dc68c-34e5-11eb-9fbd-7bb165d4566c</param-value>
+    </context-param>
+
     <listener>
         <listener-class>
             org.springframework.web.context.ContextLoaderListener
@@ -70,6 +75,7 @@
     </filter-mapping>
 
 
+    <!-- GET /management/version.txt -->
     <servlet>
         <servlet-name>showVersionNumber</servlet-name>
         <servlet-class>com.payneteasy.srvlog.ShowVersionServlet</servlet-class>
@@ -78,6 +84,18 @@
     <servlet-mapping>
         <servlet-name>showVersionNumber</servlet-name>
         <url-pattern>/management/version.txt</url-pattern>
+    </servlet-mapping>
+
+    <!-- POST /save-logs -->
+    <servlet>
+        <servlet-name>saveLogs</servlet-name>
+        <servlet-class>com.payneteasy.srvlog.servlet.SaveLogsServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>saveLogs</servlet-name>
+        <url-pattern>/save-logs/*</url-pattern>
     </servlet-mapping>
 
 </web-app>


### PR DESCRIPTION
Collect logs on /save-logs url.

Request example:

```json
{
   "requestId":"d1712806-ff5c-43b2-8d18-62bc98fbb18b",
   "messages":[
      {
         "time":1606944951857,
         "program":"test",
         "facility":16,
         "severity":7,
         "message":"message 1"
      },
      {
         "time":1606944951858,
         "program":"test",
         "facility":16,
         "severity":7,
         "message":"message 2"
      }
   ]
}

```

Response example

```json
{
   "requestId":"d1712806-ff5c-43b2-8d18-62bc98fbb18b",
   "status":"SUCCESS"
}

```

Secured by 'token' header.
